### PR TITLE
Fix bad usage of bitwise OR in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function ngConstantPlugin(opts) {
     var stream = through.obj(objectStream);
 
     if (options.noFile) {
-        stream.end(new gutil.File({ path: options.dest | 'constants.js' }));
+        stream.end(new gutil.File({ path: options.dest || 'constants.js' }));
     }
 
     return stream;


### PR DESCRIPTION
I believe the intention was to use "||" and not "|"
